### PR TITLE
Agregar meta tags faltantes

### DIFF
--- a/client/main.html
+++ b/client/main.html
@@ -1,6 +1,9 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="Description" content="Fast creation of shared Spotify playlists">
+  <!--Andrés Felipe López: Sería bueno agregar los metatags restantes para tener la información de la página completa -->
+  <meta name="keywords" content="Spotify,Blendify,Meteor">
+  <meta name="author" content="Julian Manrique & Sergio Cardenas">
   <script>document.querySelector('html').lang = 'en' /*Setting language to english*/</script>
   <title>Blendify | Share your music</title>
 


### PR DESCRIPTION
Sería bueno agregar los metatags restantes para tener la información de la página completa